### PR TITLE
프린트시 가격모델이 사라지도록 기능 추가함.

### DIFF
--- a/js/onset-pricing-eng.js
+++ b/js/onset-pricing-eng.js
@@ -49,6 +49,8 @@ function todayDateFormat() {
 
 
 function printMode() {
+	// 인쇄시에는 가격모델이 숨겨져야한다.
+	document.getElementById("priceModel").style.display = 'none';
 	window.print();
 }
 
@@ -63,6 +65,8 @@ function resetForm() {
 	document.getElementById("startdate").value = "";
 	document.getElementById("enddate").value = "";
 	document.getElementById("privacy").checked = false;
+	// 리셋을 누르면 숨겨진 가격모델을 다시 보이도록 한다.
+	document.getElementById("priceModel").style.display = 'block';
 }
 
 function sendToEmail() {

--- a/js/onset-pricing-kor.js
+++ b/js/onset-pricing-kor.js
@@ -49,6 +49,8 @@ function todayDateFormat() {
 
 
 function printMode() {
+	// 인쇄시에는 가격모델이 숨겨져야한다.
+	document.getElementById("priceModel").style.display = 'none';
 	window.print();
 }
 
@@ -63,6 +65,8 @@ function resetForm() {
 	document.getElementById("startdate").value = "";
 	document.getElementById("enddate").value = "";
 	document.getElementById("privacy").checked = false;
+	// 리셋을 누르면 숨겨진 가격모델을 다시 보이도록 한다.
+	document.getElementById("priceModel").style.display = 'block';
 }
 
 function sendToEmail() {

--- a/onset-pricing-eng.html
+++ b/onset-pricing-eng.html
@@ -26,12 +26,12 @@
     <div class="col-12 p-3">
         <img src="http://75mm.studio/img/logo_v02.svg" width=250>
     </div>
-    <h2 class="col-12 pt-4 pb-4">
-        Onset Data Acquisition Pricing
-    </h2>
 </div>
 
-<div class="container w-100">
+<div id="priceModel" class="container w-100">
+    <h2 class="text-center col-12 pt-4 pb-4">
+        Onset Data Acquisition Pricing
+    </h2>
     <div class="">
         <!--pricing start-->
         <div class="row justify-content-center">
@@ -256,7 +256,7 @@
 <div class="p-3 text-center">
     <div class="row">
         <div class="col-12 text-center" id="copyright">
-          ⓒ 2019 75mm Studio Co., Ltd. All rights reserved.
+          ⓒ 2020 75mm Studio Co., Ltd. All rights reserved.
         </div>
     </div>
 </div>

--- a/onset-pricing-kor.html
+++ b/onset-pricing-kor.html
@@ -26,13 +26,13 @@
     <div class="col-12 p-3">
         <img src="http://75mm.studio/img/logo_v02.svg" width=250>
     </div>
-    <h2 class="col-12 pt-4 pb-4">
+</div>
+
+<div id="priceModel" class="container w-100">
+    <h2 class="text-center col-12 pt-4 pb-4">
         Onset Data Acquisition<br>
         가격 정책
     </h2>
-</div>
-
-<div class="container w-100">
     <div class="">
         <!--pricing start-->
         <div class="row justify-content-center">
@@ -150,8 +150,6 @@
                 해외 촬영일 경우 출장비는 변동될 수 있습니다.
             </div>
         </div>
-        
-
         <!--copyright issues end--> 
     </div>
 </div>
@@ -258,7 +256,7 @@
 <div class="p-3 text-center">
     <div class="row">
         <div class="col-12 text-center" id="copyright">
-          ⓒ 2019 75mm Studio Co., Ltd. All rights reserved.
+          ⓒ 2020 75mm Studio Co., Ltd. All rights reserved.
         </div>
     </div>
 </div>


### PR DESCRIPTION
Close: #iss59

- reset 버튼을 누르면 다시 가격 모델이 보인다.
- 견적서의 연도가 2019년이라고 표기된것을 2020년으로 변경함.